### PR TITLE
Adding focus style in dist/css/checkboxes.css

### DIFF
--- a/dist/css/checkboxes.css
+++ b/dist/css/checkboxes.css
@@ -148,6 +148,10 @@
   background: #fcfff4;
 }
 
+[class^="ckbx-style-"] input[type="checkbox"]:focus + label:after {
+  background-color: #d7e4ee;
+}
+
 [class^="ckbx-style-"] input[type="checkbox"]:checked + label:before {
   background: #333;
 }


### PR DESCRIPTION
Adding on focus style, to checkbox, when user presses tab key.
![Checkbox](https://user-images.githubusercontent.com/4452285/92343634-d997a000-f089-11ea-9b0a-0b9ba15b1304.jpg)
